### PR TITLE
fix(auth0): keep Cordova signup on popup login style

### DIFF
--- a/auth0_client.js
+++ b/auth0_client.js
@@ -40,6 +40,13 @@ Meteor.loginWithAuth0 = function(options, callback) {
  */
 
 Auth0._loginStyle = function(config, options) {
+  // Cordova must never top-frame redirect (incl. `/_signup`) — leave WebView shell
+  if (Meteor.isCordova) {
+    return (
+      (options.loginStyle === 'inline' && 'inline') || OAuth._loginStyle('auth0', config, options)
+    )
+  }
+
   return (
     (options.path === SIGNUP_AS && 'redirect') ||
     (options.loginStyle === 'inline' && 'inline') ||


### PR DESCRIPTION
## Summary
- Skip the `/_signup` redirect force when `Meteor.isCordova` so Auth0 signup stays on popup login style.
- Prevents Cordova WebView shell from being replaced during signup.

Sibling mirror of the same fix in `meteor-packages` (`optune:auth0-oauth`). Prefer publishing via `METEOR_PACKAGE_DIRS` / `meteor-packages` when that path is used.

## Test plan
- [ ] On Cordova, open signup / Auth0 login and confirm WebView shell is not top-frame redirected
- [ ] On web, confirm existing Auth0 signup/login redirect behavior unchanged


Made with [Cursor](https://cursor.com)